### PR TITLE
Changed Weller WSP80 Rid1 from 120 ohms to 330 ohms

### DIFF
--- a/software/front/US_Firmware.X/iron.c
+++ b/software/front/US_Firmware.X/iron.c
@@ -712,7 +712,7 @@ const t_IronPars Irons[] = {
 
     {
         0, 
-        {0x1803},
+        {0x180C},
         "WELLER WSP80            ",
         {
             {


### PR DESCRIPTION
Value of Rid1 is changed from 120 to 330 ohms in order to reduce false identification of JBC C245 (Rid1=150 ohms, same Rid2) to this model, which results in a soldering cartridge becoming incandescent. The root cause of the false reading of Rid1 has not been identified. However, this breaking change seems desiderable from safety point of view.